### PR TITLE
Passing channels as arguments to functions

### DIFF
--- a/programs/main.py
+++ b/programs/main.py
@@ -1,14 +1,12 @@
 from channel import Channel, Branch
 from sessiontype import *
 
-ch = Channel[Recv[str, Send[int, End]]]()
-def f(ch, ch1) -> str:
-    ch.send(42)
-    s = ch1.recv()
-    ch.send(100)
-    ch1.send(1239)
-    return s
 
-
-f(Channel[Send[int, Send[int, End]]](), ch)
-
+def ok():
+    def f(ch, ch1) -> str:
+        ch.send(42)
+        s = ch1.recv()
+        ch.send(100)
+        ch1.send(1239)
+        return s
+    f(Channel[Send[int, Send[int, End]]](), Channel[Recv[str, Send[int, End]]]())

--- a/programs/main.py
+++ b/programs/main.py
@@ -1,15 +1,14 @@
 from channel import Channel, Branch
 from sessiontype import *
 
-chan = Channel[Send[int, Send[int, End]]]()
-chan1 = Channel[Recv[str, Recv[str, End]]]()
 
 def f(ch, ch1) -> str:
     ch.send(42)
     s = ch1.recv()
+    ch.send(100)
+    ch1.send(1239)
     return s
 
-x = f(chan, chan1)
-y = f(chan, chan1)
 
+f(Channel[Send[int, Send[bool, End]]](), Channel[Recv[str, Send[int, End]]]())
 

--- a/programs/main.py
+++ b/programs/main.py
@@ -1,7 +1,7 @@
 from channel import Channel, Branch
 from sessiontype import *
 
-
+ch = Channel[Recv[str, Send[int, End]]]()
 def f(ch, ch1) -> str:
     ch.send(42)
     s = ch1.recv()
@@ -10,5 +10,5 @@ def f(ch, ch1) -> str:
     return s
 
 
-f(Channel[Send[int, Send[bool, End]]](), Channel[Recv[str, Send[int, End]]]())
+f(Channel[Send[int, Send[int, End]]](), ch)
 

--- a/programs/main.py
+++ b/programs/main.py
@@ -1,8 +1,15 @@
 from channel import Channel, Branch
 from sessiontype import *
 
-ch = Channel[Send[List[int], Send[Tuple[str, int], Send[Dict[int, float], End]]]]()
+chan = Channel[Send[int, Send[int, End]]]()
+chan1 = Channel[Recv[str, Recv[str, End]]]()
 
-ch.send([1,2])
-ch.send(('cool', 42))
-ch.send({3: 3.14})
+def f(ch, ch1) -> str:
+    ch.send(42)
+    s = ch1.recv()
+    return s
+
+x = f(chan, chan1)
+y = f(chan, chan1)
+
+

--- a/src/check.py
+++ b/src/check.py
@@ -1,5 +1,7 @@
 import ast
+from cgi import test
 import copy
+from subprocess import call
 import sys
 from ast import *
 from functools import reduce
@@ -11,16 +13,42 @@ from lib import *
 from statemachine import STParser, Node, TLeft, TRight, TGoto
 from sessiontype import STR_ST_MAPPING, SessionException
 
-
 class TypeChecker(NodeVisitor):
 
-    def __init__(self, tree, inside_class=False) -> None:
+    def __init__(self, tree, inside_class=False, test_mode=True) -> None:
         self.inside_class = inside_class
+        self.function_queue = {}
+        self.functions_that_alter_channels = {}
+        self.subst_var = {}
+        self.test_mode = test_mode
         self.environments: ImmutableList[Environment] = ImmutableList().add(Environment())
         self.in_functions: ImmutableList[FunctionDef] = ImmutableList()
         self.loop_entrypoints = set() # TODO: consider putting into environment
         self.visit(tree)
+        if self.test_mode:
+            self.visit_functions()
         self.validate_postcondition()
+
+    def visit_and_drop_function(self, key: str) -> None:
+        env = self.get_latest_scope()
+        #assert key in self.function_queue and not env.contains_function(key), "You may only call this function if you know we haven't evaluated it yet"
+        function = self.function_queue[key] if key in self.function_queue else self.functions_that_alter_channels[key]
+        self.visit(function)
+        if key in self.function_queue:
+            del self.function_queue[key]
+
+
+    def visit_functions(self):
+        """
+        For testing to work we would have to exhaust the dictionary of functions
+        before checking post-conditions.
+        Due to nested function, we need to do it inside a loop.
+        """
+        while self.function_queue:
+            for name in list(self.function_queue.keys()):
+                self.visit_and_drop_function(name)
+        
+
 
     def validate_postcondition(self):
         latest = self.get_latest_scope()
@@ -37,6 +65,11 @@ class TypeChecker(NodeVisitor):
             raise SessionException(msgs)
 
     def visit_FunctionDef(self, node: FunctionDef) -> Typ:
+        in_queue = self.in_function_queue(node.name)
+        if not in_queue and not self.inside_class:
+            self.function_queue[node.name] = node
+        if not in_queue and node.name not in self.functions_that_alter_channels and not self.inside_class:
+            return
         self.in_functions = self.in_functions.add(node)
 
         expected_return_type: type = self.get_return_type(node)
@@ -50,13 +83,24 @@ class TypeChecker(NodeVisitor):
         self.get_latest_scope().bind_func(node.name, function_type.items())
         self.dup()
         for (v, t) in params:
-            self.bind_var(v, t)
+            if not v in self.subst_var:
+                self.bind_var(v, t)
 
         for stm in node.body:
             self.visit(stm)
 
-        self.pop()
 
+        # Popping, but if we updated any channels in a lower scope, we need to
+        # bring them up to speed
+        env = self.pop()
+        chans = env.get_kind(Node)
+        for name, ch in chans:
+            current_env = self.get_latest_scope()
+            if current_env.contains_variable(name):
+                self.functions_that_alter_channels[node.name] = node
+                self.bind_var(name, ch)
+
+        
         self.in_functions = self.in_functions.tail()
 
         return function_type.items()
@@ -131,12 +175,17 @@ class TypeChecker(NodeVisitor):
 
     def visit_Name(self, node: Name) -> Tuple[str, Typ] | Typ:
         debug_print('visit_Name', dump(node))
-        if node.id == 'DEBUG':
+        name = node.id
+        if name == 'DEBUG':
             return self
-        opt = str_to_typ(node.id)
-        return opt or self.get_latest_scope().lookup_var_or_default(node.id,
+        if name in self.subst_var:
+            name = self.subst_var[name]
+        if name in self.functions_that_alter_channels:
+            return name
+        opt = str_to_typ(name)
+        return opt or self.get_latest_scope().lookup_var_or_default(name,
                                                                     self.get_latest_scope().lookup_func_or_default(
-                                                                        node.id, node.id))
+                                                                        name, name))
 
     def visit_Tuple(self, node: Tuple) -> None:
         debug_print('visit_Tuple', dump(node))
@@ -217,15 +266,38 @@ class TypeChecker(NodeVisitor):
     def visit_Constant(self, node: Constant) -> type:
         return type(node.value)
 
+    def in_function_queue(self, key) -> bool:
+        return type(key) is str and key in self.function_queue
+
     def visit_Call(self, node: Call) -> Typ:
         debug_print('visit_Call', dump(node))
         call_func = self.visit(node.func)
-        
+        if isinstance(call_func, str) and (call_func in self.function_queue or call_func in self.functions_that_alter_channels):
+            visited_args = [self.visit(arg) for arg in node.args]
+            function: FunctionDef = self.function_queue[call_func] if call_func in self.function_queue else self.functions_that_alter_channels[call_func]
+            if any(isinstance(arg, Node) for arg in visited_args):
+                # We passed a channel to a function
+                params = self.visit(function.args)
+                pre_subst = copy.deepcopy(self.subst_var)
+                self.functions_that_alter_channels[call_func] = function
+                for (param, typ), (arg_ast,arg) in zip(params, zip(node.args, visited_args)):
+                    if isinstance(arg, Node) and isinstance(arg_ast, Name):
+                        self.subst_var[param] = arg_ast.id
+                
+                self.visit_and_drop_function(call_func)
+                call_func = self.visit(node.func)
+                self.subst_var = pre_subst
+
+            else:
+                self.visit_and_drop_function(call_func)
+                call_func = self.visit(node.func)
         if isinstance(call_func, tuple):
             nd = call_func[0]
             args = self.get_function_args(node.args)
             op = call_func[1]
             ch_name = node.func.value.id
+            if ch_name in self.subst_var:
+                ch_name = self.subst_var[ch_name]
             match op:
                 case 'recv':
                     valid_action, _ = nd.valid_action_type(op, None)
@@ -466,7 +538,7 @@ class TypeChecker(NodeVisitor):
     def bind_var(self, var: str, typ: Typ) -> None:
         self.get_latest_scope().bind_var(var, typ)
 
-    def print_envs(self) -> None:
+    def print_envs(self, opt_title='') -> None:
         i = 0
         for env in self.environments.items():
             print(f'Env #{i}:', env)

--- a/src/check.py
+++ b/src/check.py
@@ -267,8 +267,6 @@ class TypeChecker(NodeVisitor):
         debug_print('visit_BinOp', dump(node))
         l_typ = self.visit(node.left)
         r_typ = self.visit(node.right)
-        print('ltyp', l_typ)
-        print('rtyp', r_typ)
         return union(l_typ, r_typ)
 
     def visit_Constant(self, node: Constant) -> type:
@@ -280,11 +278,8 @@ class TypeChecker(NodeVisitor):
     def visit_Call(self, node: Call) -> Typ:
         debug_print('visit_Call', dump(node))
         call_func = self.visit(node.func)
-        print('call_func', call_func)
         if isinstance(call_func, str) and (call_func in self.function_queue or call_func in self.functions_that_alter_channels):
-            print('HERE')
             visited_args = [self.visit(arg) for arg in node.args]
-            print('args', visited_args)
             function: FunctionDef = self.function_queue[call_func] if call_func in self.function_queue else self.functions_that_alter_channels[call_func]
             if any(isinstance(arg, Node) for arg in visited_args):
                 # We passed a channel to a function
@@ -302,7 +297,6 @@ class TypeChecker(NodeVisitor):
                 self.visit_and_drop_function(call_func)
                 call_func = self.visit(node.func)
                 self.subst_var = pre_subst
-                print('call_func is now', call_func)
 
             else:
                 self.visit_and_drop_function(call_func)

--- a/src/lib.py
+++ b/src/lib.py
@@ -91,8 +91,6 @@ def union(t1: Typ, t2: Typ) -> Typ:
 
         # TODO: Extend with other collections 
     else:
-        print('t1', t1)
-        print('t2', t2)
         if issubclass(t1, t2):
             return t2
         elif issubclass(t2, t1):

--- a/src/lib.py
+++ b/src/lib.py
@@ -91,6 +91,8 @@ def union(t1: Typ, t2: Typ) -> Typ:
 
         # TODO: Extend with other collections 
     else:
+        print('t1', t1)
+        print('t2', t2)
         if issubclass(t1, t2):
             return t2
         elif issubclass(t2, t1):

--- a/src/statemachine.py
+++ b/src/statemachine.py
@@ -3,6 +3,7 @@ from typing import TypeVar, Generic, Any
 import typing
 
 from lib import Typ, parameterise, str_to_typ, to_typing
+from sessiontype import SessionException
 
 A = TypeVar('A')
 
@@ -104,6 +105,9 @@ class Node:
         state = f'(s{self.id})' if self.accepting else f's{self.id}'
         return state
 
+    def __repr__(self) -> str:
+        return f'Node(state={self.id})'
+
     def next_nd(self):
         assert len(self.outgoing) == 1, "Function should not be called if it's not a single outgoing edge"
         points_to = list(self.outgoing.values())[0]
@@ -117,6 +121,8 @@ class Node:
         return list(self.outgoing.keys())[0]
 
     def outgoing_action(self) -> TSend | TRecv:
+        if len(self.outgoing) == 0:
+            raise SessionException(f'Channel {self} is done and exhausted')
         assert len(self.outgoing) == 1, "Function should not be called if it's not a single outgoing edge"
         key = self.get_edge()
         return key.__origin__

--- a/tests/tests_helpers/context.py
+++ b/tests/tests_helpers/context.py
@@ -1,5 +1,14 @@
 import os
 import sys
+import unittest
+import inspect
+import ast
+from textwrap import dedent
+
+def get_ast(f) -> ast.Module:
+    return ast.parse(dedent(inspect.getsource(f)))
+
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-from tests.context import *
+from src.context import *

--- a/tests/tests_sessiontypes/context.py
+++ b/tests/tests_sessiontypes/context.py
@@ -1,5 +1,14 @@
 import os
 import sys
+import unittest
+import inspect
+import ast
+from textwrap import dedent
+
+def get_ast(f) -> ast.Module:
+    return ast.parse(dedent(inspect.getsource(f)))
+
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-from tests.context import *
+from src.context import *

--- a/tests/tests_sessiontypes/test_channels.py
+++ b/tests/tests_sessiontypes/test_channels.py
@@ -302,5 +302,34 @@ class TestVerifyChannels(unittest.TestCase):
         
         TypeChecker(get_ast(ok))
 
+    def test_passing_multiple_valid_channels_directly(self):
+        def ok():
+            def f(ch, ch1) -> str:
+                ch.send(42)
+                s = ch1.recv()
+                ch.send(100)
+                ch1.send(1239)
+                return s
+            f(Channel[Send[int, Send[int, End]]](), Channel[Recv[str, Send[int, End]]]())
+        TypeChecker(get_ast(ok))
+
+    def test_passing_multiple_channels_directly_with_wrong_type(self):
+        def ok():
+            def f(ch, ch1) -> str:
+                ch.send(42)
+                s = ch1.recv()
+                ch.send(100)
+                ch1.send(1239)
+                return s
+            f(Channel[Send[int, Send[bool, End]]](), Channel[Recv[str, Send[int, End]]]())
+        with self.assertRaises(SessionException):
+            TypeChecker(get_ast(ok))
+
+        
+
+
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tests_sessiontypes/test_channels.py
+++ b/tests/tests_sessiontypes/test_channels.py
@@ -325,6 +325,13 @@ class TestVerifyChannels(unittest.TestCase):
         with self.assertRaises(SessionException):
             TypeChecker(get_ast(ok))
 
+
+    def test_receiving_values_inside_send(self):
+        def ok():
+            ch = Channel[Recv[int, Recv[int, Send[int, End]]]]()
+            ch.send(ch.recv() + ch.recv())
+        TypeChecker(get_ast(ok))
+
         
 
 

--- a/tests/tests_sessiontypes/test_channels.py
+++ b/tests/tests_sessiontypes/test_channels.py
@@ -283,6 +283,24 @@ class TestVerifyChannels(unittest.TestCase):
 
         TypeChecker(get_ast(ok))
 
+    def test_simple_pass_to_function(self):
+        def ok():
+            ch = Channel[Send[int, End]]()
+            def sending_int(chan):
+                chan.send(42)
+            sending_int(ch)
+        
+        TypeChecker(get_ast(ok))
+
+    def test_twice_pass_to_function(self):
+        def ok():
+            ch = Channel[Send[int, Send[int, End]]]()
+            def sending_int(chan):
+                chan.send(42)
+            sending_int(ch)
+            sending_int(ch)
+        
+        TypeChecker(get_ast(ok))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tests_statemachine/context.py
+++ b/tests/tests_statemachine/context.py
@@ -1,5 +1,14 @@
 import os
 import sys
+import unittest
+import inspect
+import ast
+from textwrap import dedent
+
+def get_ast(f) -> ast.Module:
+    return ast.parse(dedent(inspect.getsource(f)))
+
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-from tests.context import *
+from src.context import *

--- a/tests/tests_typechecking/context.py
+++ b/tests/tests_typechecking/context.py
@@ -1,5 +1,14 @@
 import os
 import sys
+import unittest
+import inspect
+import ast
+from textwrap import dedent
+
+def get_ast(f) -> ast.Module:
+    return ast.parse(dedent(inspect.getsource(f)))
+
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
-from tests.context import *
+from src.context import *


### PR DESCRIPTION
I.e.:
```py
def f(ch, ch1) -> str:
    ch.send(42)
    s = ch1.recv()
    ch.send(100)
    ch1.send(1239)
    return s
f(Channel[Send[int, Send[int, End]]](), Channel[Recv[str, Send[int, End]]]())
```
or
```py
ch = Channel[Send[int, Send[int, End]]]()
def sending_int(chan):
    chan.send(42)
sending_int(ch)
sending_int(ch)
```

Works _mostly_ except it doesn't shadow global variables correctly.
