### PR TITLE
Dynamic types read correctly; fixes to processing of ST

### DIFF
--- a/programs/MapReduce.scr
+++ b/programs/MapReduce.scr
@@ -1,5 +1,5 @@
-type <List[str]> as workload;
-type <Dict[str, int]> as result;
+type <list[str]> as workload;
+type <dict[str, int]> as result;
 
 global protocol MapReduce(role Distributor, role c1, role c2, role c3) {
     Work(workload) from Distributor to c1;

--- a/programs/MapReduce_Distributor.py
+++ b/programs/MapReduce_Distributor.py
@@ -3,12 +3,12 @@ from context import *
 routing_table = {'self': ('localhost', 5000), 'c1': ('localhost', 5001), 'c2': ('localhost', 5002),
                  'c3': ('localhost', 5003)}
 
-ch = Channel(Send[list[str], 'c1', 
-                Send[list[str], 'c2', 
-                    Send[list[str], 'c3', 
-                        Recv[dict[str, int], 'c1', 
-                            Recv[dict[str, int], 'c2', 
-                                Recv[dict[str, int], 'c3', End]]]]]], routing_table)
+ch = Channel(Send[list[str], 'c1',
+                  Send[list[str], 'c2',
+                       Send[list[str], 'c3',
+                            Recv[dict[str, int], 'c1',
+                                 Recv[dict[str, int], 'c2',
+                                      Recv[dict[str, int], 'c3', End]]]]]], routing_table)
 
 ch.send(['Deer', 'Bear', 'River'])
 ch.send(['Car', 'Car', 'River'])

--- a/programs/MapReduce_Distributor.py
+++ b/programs/MapReduce_Distributor.py
@@ -3,9 +3,12 @@ from context import *
 routing_table = {'self': ('localhost', 5000), 'c1': ('localhost', 5001), 'c2': ('localhost', 5002),
                  'c3': ('localhost', 5003)}
 
-ch = Channel(Send[List[str], 'c1', Send[List[str], 'c2', Send[
-    List[str], 'c3', Recv[Dict[str, int], 'c1', Recv[Dict[str, int], 'c2', Recv[Dict[str, int], 'c3', End]]]]]],
-             routing_table)
+ch = Channel(Send[list[str], 'c1', 
+                Send[list[str], 'c2', 
+                    Send[list[str], 'c3', 
+                        Recv[dict[str, int], 'c1', 
+                            Recv[dict[str, int], 'c2', 
+                                Recv[dict[str, int], 'c3', End]]]]]], routing_table)
 
 ch.send(['Deer', 'Bear', 'River'])
 ch.send(['Car', 'Car', 'River'])

--- a/programs/MapReduce_c1.py
+++ b/programs/MapReduce_c1.py
@@ -3,11 +3,11 @@ from context import *
 routing_table = {'Distributor': ('localhost', 5000), 'self': ('localhost', 5001), 'c2': ('localhost', 5002),
                  'c3': ('localhost', 5003)}
 
-ch = Channel(Recv[List[str], 'Distributor', Send[Dict[str, int], 'Distributor', End]], routing_table)
+ch = Channel(Recv[list[str], 'Distributor', Send[dict[str, int], 'Distributor', End]], routing_table, static_check=False)
 
-words: List[str] = ch.recv()
+words: list[str] = ch.recv()
 
-mapping: Dict[str, int] = {}
+mapping: dict[str, int] = {}
 
 for w in words:
     mapping[w] = mapping.get(w, 0) + 1

--- a/programs/MapReduce_c2.py
+++ b/programs/MapReduce_c2.py
@@ -3,11 +3,11 @@ from context import *
 routing_table = {'Distributor': ('localhost', 5000), 'c1': ('localhost', 5001), 'self': ('localhost', 5002),
                  'c3': ('localhost', 5003)}
 
-ch = Channel(Recv[List[str], 'Distributor', Send[Dict[str, int], 'Distributor', End]], routing_table)
+ch = Channel(Recv[list[str], 'Distributor', Send[dict[str, int], 'Distributor', End]], routing_table, static_check=False)
 
-words: List[str] = ch.recv()
+words: list[str] = ch.recv()
 
-mapping: Dict[str, int] = {}
+mapping: dict[str, int] = {}
 
 for w in words:
     mapping[w] = mapping.get(w, 0) + 1

--- a/programs/MapReduce_c3.py
+++ b/programs/MapReduce_c3.py
@@ -3,11 +3,11 @@ from context import *
 routing_table = {'Distributor': ('localhost', 5000), 'c1': ('localhost', 5001), 'c2': ('localhost', 5002),
                  'self': ('localhost', 5003)}
 
-ch = Channel(Recv[List[str], 'Distributor', Send[Dict[str, int], 'Distributor', End]], routing_table)
+ch = Channel(Recv[list[str], 'Distributor', Send[dict[str, int], 'Distributor', End]], routing_table, static_check=False)
 
-words: List[str] = ch.recv()
+words: list[str] = ch.recv()
 
-mapping: Dict[str, int] = {}
+mapping: dict[str, int] = {}
 
 for w in words:
     mapping[w] = mapping.get(w, 0) + 1

--- a/src/channel.py
+++ b/src/channel.py
@@ -9,7 +9,7 @@ from lib import expect, parameterize, type_to_str, union
 from sessiontype import *
 import socket
 from stack import Stack
-from statemachine import Action, BranchEdge, from_generic_alias, Node, print_node
+from statemachine import Action, BranchEdge, from_generic_alias, Node
 from check import typecheck_file
 from debug import debug_print
 
@@ -183,7 +183,7 @@ class Channel(Generic[T]):
             except Exception as ex:
                 _trace(ex)
 
-    def _read_dynamic_type(self, obj: object):
+    def _read_dynamic_type(self, obj: object) -> type:
         if isinstance(obj, list):
             reduced_typ = reduce(union, [type(elem) for elem in obj])
             return List[reduced_typ]
@@ -224,8 +224,8 @@ class Channel(Generic[T]):
                     raise RuntimeError(f'Expected to {expected_action}, choose/offer was called')
                 for edge in self.session_type.outgoing:
                     expect(isinstance(edge, BranchEdge),
-                        f"Outgoing edges should be BranchEdge, got {edge}",
-                        exc=RuntimeError)
+                           f"Outgoing edges should be BranchEdge, got {edge}",
+                           exc=RuntimeError)
                     if edge.key == message:
                         self.session_type = self.session_type.outgoing[edge]
                         break

--- a/src/channel.py
+++ b/src/channel.py
@@ -1,14 +1,15 @@
+from functools import reduce
 import sys
 import traceback
 from threading import Thread
 from types import GenericAlias
-from typing import Any, Dict
+from typing import Any, Dict, List, Set, Tuple
 import pickle
-from lib import expect, type_to_str
+from lib import expect, parameterize, type_to_str, union
 from sessiontype import *
 import socket
 from stack import Stack
-from statemachine import Action, BranchEdge, from_generic_alias, Node
+from statemachine import Action, BranchEdge, from_generic_alias, Node, print_node
 from check import typecheck_file
 from debug import debug_print
 
@@ -182,6 +183,20 @@ class Channel(Generic[T]):
             except Exception as ex:
                 _trace(ex)
 
+    def _read_dynamic_type(self, obj: object):
+        if isinstance(obj, list):
+            reduced_typ = reduce(union, [type(elem) for elem in obj])
+            return List[reduced_typ]
+        elif isinstance(obj, dict):
+            key_typ = reduce(union, [type(elem) for elem in obj.keys()])
+            val_typ = reduce(union, [type(elem) for elem in obj.values()])
+            return Dict[key_typ, val_typ]
+        elif isinstance(obj, tuple):
+            return parameterize(Tuple, [type(elem) for elem in obj])
+        elif isinstance(obj, set):
+            return parameterize(Set, [type(elem) for elem in obj])
+        return type(obj)
+
     def _try_advance(self, action: Action, message: str | None) -> None:
         """Try to advance the current session type, throws an exception if the operation or type was unexpected
 
@@ -194,11 +209,11 @@ class Channel(Generic[T]):
         """
         next_action = self.session_type.outgoing_action()
         expected_action = 'branch' if isinstance(self.session_type.get_edge(), Branch) else self.session_type.get_edge()
-
+        argument_typ = self._read_dynamic_type(message)
         match action:
             case action.SEND:
-                if not action == next_action or not self.session_type.outgoing_type() == type(message):
-                    raise RuntimeError(f'Expected to {expected_action}, end {type_to_str(type(message))} was called')
+                if not action == next_action or not self.session_type.outgoing_type() == argument_typ:
+                    raise RuntimeError(f'Expected to {expected_action}, end {type_to_str(argument_typ)} was called')
                 self.session_type = self.session_type.next_nd()
             case action.RECV:
                 if not action == next_action:

--- a/src/check.py
+++ b/src/check.py
@@ -167,8 +167,7 @@ class TypeChecker(NodeVisitor):
             for post_chan in post_channels:
                 chan_id = post_chan.identifier
                 expect(chan_id in self.env().loop_entrypoints or chan_id in self.env().loop_breakpoints,
-                       f'loop error: needs to {post_chan.outgoing_action()} {post_chan.outgoing_type()}',
-                       node)
+                       f'loop error: needs to {post_chan}')
 
     def process_and_substitute(self, node):
         stubs = self.env().get_kind(SessionStub)

--- a/src/check.py
+++ b/src/check.py
@@ -50,15 +50,6 @@ class TypeChecker(NodeVisitor):
             msgs = '\n'.join(failing_channels)
             raise SessionException(msgs)
 
-    def is_builtin(self, typ):
-        return typ in sys.builtin_module_names or \
-               isinstance(typ, BuiltinFunctionType) or \
-               isinstance(typ, BuiltinMethodType) or \
-               isinstance(typ, ModuleType)
-
-    def is_dictionary(self, typ):
-        return isinstance(typ, ContainerType) and typ._name == 'Dict'
-
     def process_function(self, node: FunctionDef) -> Typ:
         self.in_functions = self.in_functions.add(node)
         expected_return_type: type = self.get_return_type(node)
@@ -661,17 +652,6 @@ def typechecker_from_path(file) -> object | TypeChecker:
 
 def typecheck_file():
     return typechecker_from_path(sys.argv[0])
-
-
-def typecheck_function(function_def):
-    function_src: str = dedent(inspect.getsource(function_def))
-    module: Module = ast.parse(function_src)
-    assert len(module.body) == 1, "Only expecting one element: a FunctionDef"
-    function_ast = module.body[0]
-    assert isinstance(function_ast, FunctionDef), "Decorator called on non-FunctionDef"
-    typechecker: TypeChecker = TypeChecker(function_ast)
-    typechecker.run()
-    return function_def
 
 
 def typecheck_function(function_def):

--- a/src/lib.py
+++ b/src/lib.py
@@ -138,8 +138,7 @@ def to_typing(typ: type):
         return Any
     elif isinstance(typ, ModuleType):
         return typ.__name__
-    else:
-        raise Exception(f'to_typing: unsupported built-in type: {typ}')
+    return typ
 
 
 def parameterize(container: Typ, typ: List[Typ] | type) -> str | list[Any] | tuple[Any, ...] | Any:

--- a/src/stack.py
+++ b/src/stack.py
@@ -65,3 +65,6 @@ class Stack(Generic[T]):
             if the stack is empty
         """
         return len(self._lst) == 0
+
+    def __repr__(self) -> str:
+        return str(self._lst)


### PR DESCRIPTION
Session types should be written using lowercase `types` syntax, such as:

```py
ch = Channel(Send[dict[str, int], "B2", Send[list[bool], "Seller", End]], routing_table)

kv = {"hello": 42}
ch.send(kv)
ch.send([1 < 3, False])
```

Various small fixes to processing of this too.